### PR TITLE
chore: update CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # Master CircleCI config template for PHEE Java components.
 # Distributed to all repos by java_version_config_updater.py.
 # Template variables substituted by the script:
-#   cimg/openjdk:21.0.7  - e.g. cimg/openjdk:17.0
+#   cimg/openjdk:21.0.11  - e.g. cimg/openjdk:17.0
 #   {{CHECKSTYLE}}         - ./gradlew checkstyleMain (present or commented out)
 
 executors:
@@ -13,7 +13,7 @@ executors:
     # The executor JDK is only used to compile the JAR — the final Docker
     # image base is set independently in each repo's Dockerfile.
     docker:
-      - image: cimg/openjdk:21.0.7
+      - image: cimg/openjdk:21.0.11
     environment:
       JVM_OPTS: -Xmx512m
       TERM: dumb


### PR DESCRIPTION
Automated update from `config_propagator.py` — standardising CircleCI pipeline config.
update the JDK image to image: cimg/openjdk:21.0.11

- Checkstyle: disabled (not declared in build.gradle/.kts)
